### PR TITLE
Remove --docker-bridge-address

### DIFF
--- a/articles/aks/configure-kubenet.md
+++ b/articles/aks/configure-kubenet.md
@@ -137,7 +137,6 @@ For more information to help you decide which network model to use, see [Compare
         --service-cidr 10.0.0.0/16 \
         --dns-service-ip 10.0.0.10 \
         --pod-cidr 10.244.0.0/16 \
-        --docker-bridge-address 172.17.0.1/16 \
         --vnet-subnet-id $SUBNET_ID    
     ```
 


### PR DESCRIPTION
Option '--docker-bridge-address' has been deprecated and will be removed in a future release.